### PR TITLE
Use lowercase username

### DIFF
--- a/gerrit.js
+++ b/gerrit.js
@@ -50,7 +50,7 @@ module.exports.run = function run( query, options )
     {
         ssh.connect( {
             host: query.server,
-            username: os.userInfo().username,
+            username: os.userInfo().username.toLowerCase(),
             port: query.port,
             privateKey: query.keyFile
         } ).then( function()


### PR DESCRIPTION
Gerrit typically uses lowercase names, while the OS username
can be capitalized.